### PR TITLE
Improve memory utilization in the pure Java path

### DIFF
--- a/src/test/java/com/lambdaworks/crypto/test/SCryptTest.java
+++ b/src/test/java/com/lambdaworks/crypto/test/SCryptTest.java
@@ -28,6 +28,11 @@ public class SCryptTest {
 
         assertArrayEquals(decode(DK), SCrypt.scrypt(P, S, N, r, p, dkLen));
 
+        // verify that all arrays are initialized in the algorithm and no bits survive each round
+    	SCrypt sc = new SCrypt(N,r,p);
+        assertArrayEquals(decode(DK), sc.scrypt(P, S, dkLen));
+        assertArrayEquals(decode(DK), sc.scrypt(P, S, dkLen));
+    	
         P = "pleaseletmein".getBytes("UTF-8");
         S = "SodiumChloride".getBytes("UTF-8");
         N = 16384;


### PR DESCRIPTION
This improves the general case by allocating small re-used primitive arrays and passing them up the stack into blockmix_salsa8 and salsa20_8. Unfortunately even jdk7 doesn't seem to stack allocate these. Taking this one step further I make all major buffers class fields for a near constant memory profile.

Also fixed the exceptions thrown when running on Windows.

Here is a "bad case" performance difference, measured over loops of 10 averaged in runs of 50 on i7-3930K which shows gains as little as 2-3%. It's possible to create N,r,p combinations like 256,16,1 which greatly exaggerate the performance difference.

columns: N, r, p, ave(50) nanos per invocation, ave(50) bytes delta per loop of 10

Round 1

8192    8       1       7.677132172E7   4.802926571428572E7
8192    9       1       8.593538972E7   5.843984088888889E7
8192    10      1       9.526296554E7   6.4078846666666664E7
8192    11      1       1.0436935362E8  5.68130032E7
16384   8       1       1.501082958E8   6.402281548387097E7
16384   9       1       1.6824245094E8  9.790573938461539E7
16384   10      1       1.871972998E8   1.1331258633333333E8
16384   11      1       2.0516909732E8  1.4749913933333334E8
32768   8       1       2.9725410802E8  1.3370965007407407E8
32768   9       1       3.3364132114E8  1.43921864E8
32768   10      1       3.7131039344E8  1.539255297142857E8
32768   11      1       4.0709769344E8  2.3783391292307693E8

Round 2 - extract int arrays B32, x to parent blockmix_salsa8
driving down memory pressure

8192    8       1       7.541511396E7   10606.56
8192    9       1       8.39292394E7    213994.44897959183
8192    10      1       9.383809952E7   2207950.6666666665
8192    11      1       1.0252205956E8  3988968.0

Round 3 - extract arrays X, B32, x to parent smix
further driving down memory pressure

8192    8       1       7.567288484E7   929608.6857142857
8192    9       1       8.426645256E7   209807.2
8192    10      1       9.396060928E7   218558.16666666666
8192    11      1       1.072375194E8   209822.72
16384   8       1       1.4782262128E8  6826663.0
16384   9       1       1.6573762662E8  419523.04

Round 4 - extract working arrays B, XY, V into class fields
very close to a constant memory profile

8192    8       1       7.534449092E7   104.16326530612245
8192    9       1       8.486543134E7   46.53061224489796
8192    10      1       9.311034794E7   53.06122448979592
8192    11      1       1.0058963958E8  46.53061224489796
16384   8       1       1.474089465E8   46.53061224489796
16384   9       1       1.6655495584E8  46.53061224489796
16384   10      1       1.8330988716E8  46.53061224489796
16384   11      1       1.9819719774E8  46.53061224489796
32768   8       1       2.9227427122E8  46.53061224489796
32768   9       1       3.3014280414E8  46.53061224489796
32768   10      1       3.6368373274E8  46.53061224489796
32768   11      1       3.934064224E8   46.53061224489796
