### PR TITLE
Pull request for an scrypt method that takes the salt as an argument.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,34 @@
           </execution>
         </executions>
       </plugin>
-    </plugins>
+
+		<plugin>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-source-plugin</artifactId>
+			<version>2.1.2</version>
+			<executions>
+				<execution>
+					<goals>
+						<goal>jar</goal>
+					</goals>
+				</execution>
+			</executions>
+		</plugin>
+
+		<plugin>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-jar-plugin</artifactId>
+			<version>2.4</version>
+			<configuration>
+				<archive>
+					<manifestEntries>
+						<Implementation-Version>${project.version}</Implementation-Version>
+					</manifestEntries>
+				</archive>
+			</configuration>
+		</plugin>
+
+	</plugins>
   </build>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
 
   <groupId>com.lambdaworks</groupId>
   <artifactId>scrypt</artifactId>
-  <version>1.3.2</version>
+  <version>1.3.2.XOOM</version>
 
   <packaging>jar</packaging>
 
   <name>scrypt</name>
   <description>Java implementation of scrypt</description>
-  <url>http://github.com/wg/scrypt</url>
+  <url>http://github.com/rlubbat/scrypt</url>
 
   <licenses>
     <license>
@@ -26,6 +26,12 @@
       <id>will</id>
       <name>Will Glozer</name>
     </developer>
+	  <developer>
+		  <id>rlubbat</id>
+		  <name>Ramsey Lubbat</name>
+		  <organization>Xoom</organization>
+		  <organizationUrl>https://www.xoom.com</organizationUrl>
+	  </developer>
   </developers>
 
   <dependencies>
@@ -124,9 +130,9 @@
   </properties>
 
   <scm>
-    <connection>scm:git:git://github.com/wg/scrypt.git</connection>
-    <developerConnection>scm:git:git://github.com/wg/scrypt.git</developerConnection>
-    <url>http://github.com/wg/scrypt</url>
+    <connection>scm:git:git://github.com/rlubbat/scrypt.git</connection>
+    <developerConnection>scm:git:git://github.com/rlubbat/scrypt.git</developerConnection>
+    <url>http://github.com/rlubbat/scrypt</url>
   </scm>
 
   <distributionManagement>

--- a/src/test/java/com/lambdaworks/crypto/test/SCryptTest.java
+++ b/src/test/java/com/lambdaworks/crypto/test/SCryptTest.java
@@ -5,18 +5,20 @@ package com.lambdaworks.crypto.test;
 import com.lambdaworks.crypto.SCrypt;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-import static com.lambdaworks.crypto.test.CryptoTestUtil.*;
-import static com.lambdaworks.crypto.SCrypt.*;
+import static com.lambdaworks.crypto.SCrypt.scrypt;
+import static com.lambdaworks.crypto.test.CryptoTestUtil.decode;
+import static org.junit.Assert.assertArrayEquals;
 
 public class SCryptTest {
+
+    // empty key & salt test missing because unsupported by JCE
+
+    // from scrypt paper appendix b
     @Test
-    public void scrypt_paper_appendix_b() throws Exception {
+    public void scrypt_N_1024() throws Exception {
         byte[] P, S;
         int N, r, p, dkLen;
         String DK;
-
-        // empty key & salt test missing because unsupported by JCE
 
         P = "password".getBytes("UTF-8");
         S = "NaCl".getBytes("UTF-8");
@@ -27,6 +29,14 @@ public class SCryptTest {
         DK = "fdbabe1c9d3472007856e7190d01e9fe7c6ad7cbc8237830e77376634b3731622eaf30d92e22a3886ff109279d9830dac727afb94a83ee6d8360cbdfa2cc0640";
 
         assertArrayEquals(decode(DK), SCrypt.scrypt(P, S, N, r, p, dkLen));
+    }
+
+    // from scrypt paper appendix b
+    @Test
+    public void scrypt_N_16384() throws Exception {
+        byte[] P, S;
+        int N, r, p, dkLen;
+        String DK;
 
         P = "pleaseletmein".getBytes("UTF-8");
         S = "SodiumChloride".getBytes("UTF-8");
@@ -37,6 +47,14 @@ public class SCryptTest {
         DK = "7023bdcb3afd7348461c06cd81fd38ebfda8fbba904f8e3ea9b543f6545da1f2d5432955613f0fcf62d49705242a9af9e61e85dc0d651e40dfcf017b45575887";
 
         assertArrayEquals(decode(DK), scrypt(P, S, N, r, p, dkLen));
+    }
+
+    // from scrypt paper appendix b
+    @Test
+    public void scrypt_N_1048576() throws Exception {
+        byte[] P, S;
+        int N, r, p, dkLen;
+        String DK;
 
         P = "pleaseletmein".getBytes("UTF-8");
         S = "SodiumChloride".getBytes("UTF-8");
@@ -67,8 +85,8 @@ public class SCryptTest {
     public void scrypt_invalid_N_large() throws Exception {
         byte[] P = "pleaseletmein".getBytes("UTF-8");
         byte[] S = "SodiumChloride".getBytes("UTF-8");
-        int    r = 8;
-        int    N = Integer.MAX_VALUE / 128;
+        int r = 8;
+        int N = Integer.MAX_VALUE / 128;
         scrypt(P, S, N, r, 1, 64);
     }
 

--- a/src/test/java/com/lambdaworks/crypto/test/SCryptUtilTest.java
+++ b/src/test/java/com/lambdaworks/crypto/test/SCryptUtilTest.java
@@ -6,15 +6,19 @@ import com.lambdaworks.codec.Base64;
 import com.lambdaworks.crypto.SCryptUtil;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.Arrays;
+
 import static org.junit.Assert.*;
 
 public class SCryptUtilTest {
+
+    private static final int N = 16384;
+    private static final int r = 8;
+    private static final int p = 1;
+
     @Test
     public void scrypt() {
-        int N = 16384;
-        int r = 8;
-        int p = 1;
-
         String hashed = SCryptUtil.scrypt("secret", N, r, p);
         String[] parts = hashed.split("\\$");
 
@@ -31,12 +35,96 @@ public class SCryptUtilTest {
     }
 
     @Test
+    public void scrypt_WithSpecifiedSalt() {
+        byte[] salt = new byte[16];
+        Arrays.fill(salt, (byte) 1);
+
+        String hashed = SCryptUtil.scrypt("secret", salt, N, r, p);
+        String[] parts = hashed.split("\\$");
+
+        assertEquals(5, parts.length);
+        assertEquals("s0", parts[1]);
+        Assert.assertEquals(16, Base64.decode(parts[3].toCharArray()).length);
+        assertEquals(32, Base64.decode(parts[4].toCharArray()).length);
+
+        int params = Integer.valueOf(parts[2], 16);
+
+        assertEquals(N, (int) Math.pow(2, params >> 16 & 0xff));
+        assertEquals(r, params >>  8 & 0x0f);
+        assertEquals(p, params >>  0 & 0x0f);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void scrypt_WithNullSalt() {
+        SCryptUtil.scrypt("secret", null, N, r, p);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void scrypt_WithTooShortSalt() {
+        byte[] salt = new byte[15];
+        Arrays.fill(salt, (byte) 1);
+
+        SCryptUtil.scrypt("secret", salt, N, r, p);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void scrypt_WithTooLongSalt() {
+        byte[] salt = new byte[17];
+        Arrays.fill(salt, (byte) 1);
+
+        SCryptUtil.scrypt("secret", salt, N, r, p);
+    }
+
+    @Test
+    public void scrypt_WithSameSalt() {
+        String passwd = "secret";
+        byte[] salt = new byte[16];
+        Arrays.fill(salt, (byte) 1);
+
+        String hashed1 = SCryptUtil.scrypt(passwd, salt, N, r, p);
+        String hashed2 = SCryptUtil.scrypt(passwd, salt, N, r, p);
+
+        assertTrue(hashed1.equals(hashed2));
+    }
+
+    @Test
     public void check() {
         String passwd = "secret";
 
-        String hashed = SCryptUtil.scrypt(passwd, 16384, 8, 1);
+        String hashed = SCryptUtil.scrypt(passwd, N, r, p);
 
         assertTrue(SCryptUtil.check(passwd, hashed));
         assertFalse(SCryptUtil.check("s3cr3t", hashed));
     }
+
+    @Test
+    public void check_WithSpecifiedSalt() {
+        String passwd = "secret";
+        byte[] salt = new byte[16];
+        Arrays.fill(salt, (byte) 1);
+
+        String hashed = SCryptUtil.scrypt(passwd, salt, N, r, p);
+
+        assertTrue(SCryptUtil.check(passwd, hashed));
+        assertFalse(SCryptUtil.check("s3cr3t", hashed));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void check_InvalidHashValueWrongNumberOfParts() {
+        SCryptUtil.check("secret", "$s0$PARAMS$SALT$KEY$EXTRA");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void check_InvalidHashValueWrongVersion() {
+        SCryptUtil.check("secret", "$s1$PARAMS$SALT$KEY");
+    }
+
+    @Test
+    public void generateSalt() {
+        final byte[] bytes = SCryptUtil.generateSalt();
+        assertTrue(bytes != null);
+        // verify 128 bit salt generation
+        assertTrue(bytes.length == 16);
+    }
+
 }


### PR DESCRIPTION
I made changes to add an scrypt method that allows for passing in the salt in the rare case where you actually want to hash something to the same hash value. An example is hashing credit card numbers in order to detect duplicates without storing the actual card number.

The changes also include full unit test coverage to ensure no breakage.

Thanks for your consideration.
