### PR TITLE
getter for native_library_loaded

### DIFF
--- a/src/main/java/com/lambdaworks/crypto/SCrypt.java
+++ b/src/main/java/com/lambdaworks/crypto/SCrypt.java
@@ -29,6 +29,14 @@ public class SCrypt {
     }
 
     /**
+     * Tells if the native lib has been successfully loaded.
+     * @return <code>true</code> while working on native lib.
+     */
+    public static boolean isNativeImpl(){
+        return native_library_loaded;
+    }
+
+    /**
      * Implementation of the <a href="http://www.tarsnap.com/scrypt/scrypt.pdf"/>scrypt KDF</a>.
      * Calls the native implementation {@link #scryptN} when the native library was successfully
      * loaded, otherwise calls {@link #scryptJ}.


### PR DESCRIPTION
Added a getter to be able to know if we are working on native lib or plain java.
Perfs s*cks when your library is not loading properly ;)
