### PR TITLE
Use more commonly used scrypt parameter names.

### DIFF
--- a/src/main/java/com/lambdaworks/crypto/SCrypt.java
+++ b/src/main/java/com/lambdaworks/crypto/SCrypt.java
@@ -35,8 +35,8 @@ public class SCrypt {
      *
      * @param passwd    Password.
      * @param salt      Salt.
-     * @param N         CPU cost parameter.
-     * @param r         Memory cost parameter.
+     * @param N         CPU/memory cost parameter.
+     * @param r         Block size parameter.
      * @param p         Parallelization parameter.
      * @param dkLen     Intended length of the derived key.
      *
@@ -54,8 +54,8 @@ public class SCrypt {
      *
      * @param passwd    Password.
      * @param salt      Salt.
-     * @param N         CPU cost parameter.
-     * @param r         Memory cost parameter.
+     * @param N         CPU/memory cost parameter.
+     * @param r         Block size parameter.
      * @param p         Parallelization parameter.
      * @param dkLen     Intended length of the derived key.
      *
@@ -68,8 +68,8 @@ public class SCrypt {
      *
      * @param passwd    Password.
      * @param salt      Salt.
-     * @param N         CPU cost parameter.
-     * @param r         Memory cost parameter.
+     * @param N         CPU/memory cost parameter.
+     * @param r         Block size parameter.
      * @param p         Parallelization parameter.
      * @param dkLen     Intended length of the derived key.
      *

--- a/src/main/java/com/lambdaworks/crypto/SCryptUtil.java
+++ b/src/main/java/com/lambdaworks/crypto/SCryptUtil.java
@@ -33,8 +33,8 @@ public class SCryptUtil {
      * in {@link SCryptUtil}.
      *
      * @param passwd    Password.
-     * @param N         CPU cost parameter.
-     * @param r         Memory cost parameter.
+     * @param N         CPU/memory cost parameter.
+     * @param r         Block size parameter.
      * @param p         Parallelization parameter.
      *
      * @return The hashed password.


### PR DESCRIPTION
I think it's better to follow the "official" naming [used by Percival](https://www.tarsnap.com/scrypt/scrypt.pdf) to avoid the confusion seen in e.g. [this SO thread](https://stackoverflow.com/questions/11126315/what-are-optimal-scrypt-work-factors). Calling r just a 'memory cost parameter' seems misleading.